### PR TITLE
Fix cookie getter returns null instead of string "null"

### DIFF
--- a/src/helpers/cookie.ts
+++ b/src/helpers/cookie.ts
@@ -64,8 +64,7 @@ function get(auth: Auth, key: string): string | null {
       })
       .find(([keyTest]) => {
         return keyTest === key
-        // eslint-disable-next-line quotes
-      })?.[1] ?? '"null"'
+      })?.[1] ?? "null"
   )
 }
 


### PR DESCRIPTION
Closes #83

The get function in the cookie helper would always return a string "null", when the value was not found. A normal null should be returned, otherwise it would be seen as a filled object.

This would result in a true for the second condition in the if statement in Auth.th on line 280.

```
if (auth.state.authenticated === null && $token.get(auth, null)) {
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cookie retrieval to return the correct fallback value when a requested cookie key is not found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->